### PR TITLE
Bugfix/ge 121

### DIFF
--- a/clientes/widgets.py
+++ b/clientes/widgets.py
@@ -303,12 +303,25 @@ class UsuarioSelectorWidget(forms.SelectMultiple):
                     var checkbox = row.querySelector('.user-checkbox');
                     if (checkbox) {{
                         checkbox.checked = !checkbox.checked;
-                        updateUIFast(); // Actualización inmediata
                         
-                        // Trigger change event para mantener consistencia
-                        var event = new Event('change');
-                        event.bubbles = true;
-                        checkbox.dispatchEvent(event);
+                        // Actualizar UI inmediatamente
+                        updateUIFast();
+                        
+                        // Actualizar el select original inmediatamente
+                        updateOriginalSelect();
+                        
+                        // Actualizar el estado del "seleccionar todo" checkbox
+                        var allVisible = document.querySelectorAll('tr[data-widget="' + widgetId + '"].usuario-row:not([style*="display: none"]) .user-checkbox');
+                        var allChecked = true;
+                        for (var i = 0; i < allVisible.length; i++) {{
+                            if (!allVisible[i].checked) {{
+                                allChecked = false;
+                                break;
+                            }}
+                        }}
+                        if (selectAllCheckbox) {{
+                            selectAllCheckbox.checked = allVisible.length > 0 && allChecked;
+                        }}
                     }}
                 }}
             }});


### PR DESCRIPTION
AL selecionar un usuario para asociar a un cliente y darle en guardar habia veces que no se guardaba. Esto ocurría por que solamente se guarda si se selecciona desde el checkbox y no desde otro lugar. Cuando se le daba click desde otro lugar se marcaba como seleccionado pero no se guardaba. Ahora eso quedó solucionado.