### PR TITLE
Corregir error de que no se muestra la fecha de nacimiento al editar usuario

### DIFF
--- a/usuarios/forms.py
+++ b/usuarios/forms.py
@@ -3,6 +3,19 @@ from django import forms
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import Group
 from datetime import date
+
+class DateInput(forms.DateInput):
+    """Widget personalizado para campos de fecha que asegura formato YYYY-MM-DD para HTML5"""
+    input_type = 'date'
+    
+    def format_value(self, value):
+        """Formatear el valor para que sea compatible con input type='date'"""
+        if value is None:
+            return ''
+        if hasattr(value, 'strftime'):
+            return value.strftime('%Y-%m-%d')
+        return str(value)
+
 class LoginForm(forms.Form):
     email = forms.EmailField(
         widget=forms.EmailInput(attrs={'class': 'form-control', 'placeholder': 'Correo electrónico'}),
@@ -45,7 +58,7 @@ class UsuarioCreationForm(forms.ModelForm):
             'nombre': forms.TextInput(attrs={'class': 'form-control'}),
             'apellido': forms.TextInput(attrs={'class': 'form-control'}),
             'cedula': forms.TextInput(attrs={'class': 'form-control'}),
-            'fecha_nacimiento': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}),
+            'fecha_nacimiento': DateInput(attrs={'class': 'form-control'}),
         }
 
     def clean(self):
@@ -95,7 +108,7 @@ class UsuarioUpdateForm(forms.ModelForm):
             'nombre': forms.TextInput(attrs={'class': 'form-control'}),
             'apellido': forms.TextInput(attrs={'class': 'form-control'}),
             'cedula': forms.TextInput(attrs={'class': 'form-control'}),
-            'fecha_nacimiento': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}),
+            'fecha_nacimiento': DateInput(attrs={'class': 'form-control'}),
         }
     
     def clean_fecha_nacimiento(self):
@@ -118,6 +131,9 @@ class UsuarioUpdateForm(forms.ModelForm):
         # Pre-cargar grupos asignados al usuario
         if self.instance and self.instance.pk:
             self.fields['groups'].initial = self.instance.groups.values_list('pk', flat=True)
+            # Asegurar que la fecha de nacimiento se muestre correctamente en el campo
+            if self.instance.fecha_nacimiento:
+                self.fields['fecha_nacimiento'].initial = self.instance.fecha_nacimiento.strftime('%Y-%m-%d')
 
     def save(self, commit=True):
         user = super().save(commit=commit)


### PR DESCRIPTION
Al hacer click en editar usuario ya se muestra la fecha de nacimiento.

Una cosa que queda pendiente es que las fechas no tienen el mismo formato.
En la lista de usuarios por ejemplo esta en formado DD-MM-YYYY, en cambio en el formulario de edicion está en formado MM-DD-YYYY.