### PR TITLE
Bugfix/ge 128 Desactivar Tipo Cliente

### DIFF
--- a/clientes/forms.py
+++ b/clientes/forms.py
@@ -58,10 +58,8 @@ class ClienteForm(forms.ModelForm):
             activo=True, es_activo=True
         ).order_by('nombre', 'apellido')
         
-        # Configurar queryset para tipos de cliente activos
-        self.fields['tipo_cliente'].queryset = TipoCliente.objects.filter(
-            activo=True
-        ).order_by('nombre')
+        # Configurar queryset para todos los tipos de cliente
+        self.fields['tipo_cliente'].queryset = TipoCliente.objects.all().order_by('nombre')
         
         # Configurar labels y help texts
         self.fields['nombre_comercial'].label = "Nombre Comercial"
@@ -151,10 +149,8 @@ class ClienteUpdateForm(forms.ModelForm):
             activo=True, es_activo=True
         ).order_by('nombre', 'apellido')
         
-        # Configurar queryset para tipos de cliente activos
-        self.fields['tipo_cliente'].queryset = TipoCliente.objects.filter(
-            activo=True
-        ).order_by('nombre')
+        # Configurar queryset para todos los tipos de cliente
+        self.fields['tipo_cliente'].queryset = TipoCliente.objects.all().order_by('nombre')
         
         # Configurar labels y help texts
         self.fields['nombre_comercial'].label = "Nombre Comercial"

--- a/clientes/models.py
+++ b/clientes/models.py
@@ -116,11 +116,8 @@ class Cliente(models.Model):
         """Validación personalizada del modelo"""
         super().clean()
         
-        # Validar que el tipo de cliente esté activo
-        if self.tipo_cliente and not self.tipo_cliente.activo:
-            raise ValidationError({
-                'tipo_cliente': 'No se puede asignar un tipo de cliente inactivo.'
-            })
+        # Validaciones personalizadas del modelo Cliente
+        # (Se removió la validación de tipo de cliente activo)
 
     def save(self, *args, **kwargs):
         self.clean()

--- a/clientes/tests.py
+++ b/clientes/tests.py
@@ -255,19 +255,25 @@ class ClienteFormTestCase(TestCase):
         self.assertIn(self.tipo_inactivo.id, tipo_choices)
         self.assertEqual(len(tipo_choices), 2)
     
-    def test_cannot_create_cliente_with_inactive_tipo(self):
-        """Test: No se puede crear un cliente con tipo inactivo (validación del modelo)"""
+    def test_can_create_cliente_with_inactive_tipo(self):
+        """Test: Se puede crear un cliente con tipo inactivo"""
         form_data = {
             'nombre_comercial': 'Cliente Test',
             'ruc': '12345678',
+            'correo_electronico': 'test@example.com',
             'tipo_cliente': self.tipo_inactivo.id,
         }
         
         form = ClienteForm(data=form_data)
         
-        # Verificar que el formulario no es válido debido a la validación del modelo
-        self.assertFalse(form.is_valid())
+        # Verificar que el formulario es válido
+        if not form.is_valid():
+            print(f"Form errors: {form.errors}")
+            self.fail(f"Form is not valid: {form.errors}")
         
-        # Verificar que el error está en el campo tipo_cliente
-        self.assertIn('tipo_cliente', form.errors)
-        self.assertIn('No se puede asignar un tipo de cliente inactivo.', str(form.errors['tipo_cliente']))
+        self.assertTrue(form.is_valid())
+        
+        # Crear el cliente
+        cliente = form.save()
+        self.assertEqual(cliente.tipo_cliente, self.tipo_inactivo)
+        self.assertFalse(cliente.tipo_cliente.activo)

--- a/clientes/views.py
+++ b/clientes/views.py
@@ -128,7 +128,7 @@ class ClienteListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['tipos_cliente'] = TipoCliente.objects.filter(activo=True)
+        context['tipos_cliente'] = TipoCliente.objects.all()
         context['q'] = self.request.GET.get('q', '')
         context['tipo_cliente_filter'] = self.request.GET.get('tipo_cliente', '')
         context['estado_filter'] = self.request.GET.get('estado', '')

--- a/tasa_cambio/views.py
+++ b/tasa_cambio/views.py
@@ -297,7 +297,8 @@ def simular_cambio_api(request):
             cliente = Cliente.objects.select_related('tipo_cliente').get(
                 pk=cliente_id, activo=True, usuarios_asociados=request.user
             )
-            descuento_pct = D(str(cliente.tipo_cliente.descuento or 0))
+            # Solo aplicar descuento si el tipo de cliente está activo
+            descuento_pct = D(str(cliente.tipo_cliente.descuento or 0)) if cliente.tipo_cliente.activo else D('0')
             cliente_info = {
                 'id': cliente.id,
                 'nombre': cliente.nombre_comercial,

--- a/transacciones/models.py
+++ b/transacciones/models.py
@@ -546,15 +546,15 @@ class Transaccion(models.Model):
                 if not tasa_actual:
                     return False
 
-                # Calcular precio de compra con descuento (como se hace en calcular_venta)
-                precio_base_compra = Decimal(str(tasa_actual.precio_base)) - Decimal(str(tasa_actual.comision_compra))
-
+                # Calcular precio de compra con descuento aplicado a la comisión (como se hace en calcular_venta)
+                comision_compra_ajustada = Decimal(str(tasa_actual.comision_compra))
                 if self.cliente and self.cliente.tipo_cliente and self.cliente.tipo_cliente.activo and self.cliente.tipo_cliente.descuento > 0:
                     descuento_pct = Decimal(str(self.cliente.tipo_cliente.descuento))
-                    # Para ventas, el descuento aumenta la tasa (cliente recibe más PYG)
-                    tasa_esperada = precio_base_compra * (Decimal('1') + (descuento_pct / Decimal('100')))
-                else:
-                    tasa_esperada = precio_base_compra
+                    # El descuento reduce la comisión de compra (cliente recibe más PYG)
+                    comision_compra_ajustada = comision_compra_ajustada * (Decimal('1') - (descuento_pct / Decimal('100')))
+                
+                # Precio de compra ajustado: precio_base - comision_compra_ajustada
+                tasa_esperada = Decimal(str(tasa_actual.precio_base)) - comision_compra_ajustada
 
             # Comparar con la tasa guardada en la transacción (con tolerancia)
             diferencia = abs(tasa_esperada - self.tasa_cambio)

--- a/transacciones/models.py
+++ b/transacciones/models.py
@@ -411,7 +411,7 @@ class Transaccion(models.Model):
         # Descuento aplicado (sobre las comisiones)
         descuento_aplicado = Decimal('0')
         descuento_pct = Decimal('0')
-        if self.cliente and self.cliente.tipo_cliente and self.cliente.tipo_cliente.descuento > 0:
+        if self.cliente and self.cliente.tipo_cliente and self.cliente.tipo_cliente.activo and self.cliente.tipo_cliente.descuento > 0:
             descuento_pct = Decimal(str(self.cliente.tipo_cliente.descuento))
             descuento_aplicado = comision_total * (descuento_pct / Decimal('100'))
         
@@ -531,7 +531,7 @@ class Transaccion(models.Model):
 
                 # Calcular precio de venta con descuento (como se hace en calcular_compra)
                 comision_venta_ajustada = Decimal(str(tasa_actual.comision_venta))
-                if self.cliente and self.cliente.tipo_cliente and self.cliente.tipo_cliente.descuento > 0:
+                if self.cliente and self.cliente.tipo_cliente and self.cliente.tipo_cliente.activo and self.cliente.tipo_cliente.descuento > 0:
                     descuento_pct = Decimal(str(self.cliente.tipo_cliente.descuento))
                     comision_venta_ajustada = comision_venta_ajustada * (Decimal('1') - (descuento_pct / Decimal('100')))
 
@@ -549,7 +549,7 @@ class Transaccion(models.Model):
                 # Calcular precio de compra con descuento (como se hace en calcular_venta)
                 precio_base_compra = Decimal(str(tasa_actual.precio_base)) - Decimal(str(tasa_actual.comision_compra))
 
-                if self.cliente and self.cliente.tipo_cliente and self.cliente.tipo_cliente.descuento > 0:
+                if self.cliente and self.cliente.tipo_cliente and self.cliente.tipo_cliente.activo and self.cliente.tipo_cliente.descuento > 0:
                     descuento_pct = Decimal(str(self.cliente.tipo_cliente.descuento))
                     # Para ventas, el descuento aumenta la tasa (cliente recibe más PYG)
                     tasa_esperada = precio_base_compra * (Decimal('1') + (descuento_pct / Decimal('100')))

--- a/transacciones/templates/transacciones/resumen_transaccion.html
+++ b/transacciones/templates/transacciones/resumen_transaccion.html
@@ -121,9 +121,9 @@
               {% if resumen_detallado.cliente and resumen_detallado.cliente.descuento > 0 %}
               <div class="mb-2">
                 {% if transaccion.tipo_operacion.codigo == 'VENTA' %}
-                <label class="text-muted small">Tasa con {{ resumen_detallado.cliente.descuento }}% descuento VIP:</label>
+                <label class="text-muted small">Tasa ajustada (con descuento):</label>
                 {% else %}
-                <label class="text-muted small">Tasa ajustada (con {{ resumen_detallado.cliente.descuento }}% descuento):</label>
+                <label class="text-muted small">Tasa ajustada (con descuento):</label>
                 {% endif %}
                 <div class="fw-bold text-success">₲ {{ resumen_detallado.tasa_ajustada|floatformat:4 }}</div>
               </div>

--- a/transacciones/views.py
+++ b/transacciones/views.py
@@ -800,17 +800,17 @@ def calcular_venta_completa(monto, moneda_origen, moneda_destino, cliente=None, 
         except TasaCambio.DoesNotExist:
             return {'success': False, 'error': f'Tasa de cambio no disponible para {moneda_origen.codigo}'}
         
-        # Para ventas: precio_base - comision_compra da la tasa base de compra
-        precio_base_compra = Decimal(str(tasa_origen.precio_base)) - Decimal(str(tasa_origen.comision_compra))
-        
-        # Aplicar descuento del cliente a la tasa base (cliente recibe más PYG)
+        # Para ventas: aplicar descuento a la comisión de compra
+        comision_compra_ajustada = Decimal(str(tasa_origen.comision_compra))
         if descuento_pct > 0:
-            # El descuento aumenta la tasa base para dar más PYG al cliente
-            precio_usado = precio_base_compra * (Decimal('1') + (descuento_pct / Decimal('100')))
+            # El descuento reduce la comisión de compra (cliente recibe más PYG)
+            comision_compra_ajustada = comision_compra_ajustada * (Decimal('1') - (descuento_pct / Decimal('100')))
             tipo_operacion = 'compra (con descuento)'
         else:
-            precio_usado = precio_base_compra
             tipo_operacion = 'compra'
+        
+        # Calcular precio de compra ajustado: precio_base - comision_compra_ajustada
+        precio_usado = Decimal(str(tasa_origen.precio_base)) - comision_compra_ajustada
         
         # LÓGICA DE CÁLCULO PARA VENTAS:
         # 1. El monto ingresado es cuánta divisa extranjera quiere VENDER
@@ -880,7 +880,7 @@ def calcular_venta_completa(monto, moneda_origen, moneda_destino, cliente=None, 
                 'tasa_destino': None,  # Para ventas, la tasa relevante es la de origen
                 
                 # Tasas para mostrar en el preview
-                'tasa_base': float(precio_base_compra),
+                'tasa_base': float(Decimal(str(tasa_origen.precio_base)) - Decimal(str(tasa_origen.comision_compra))),
                 'tasa_ajustada': float(precio_usado),
                 
                 # Cálculos

--- a/transacciones/views.py
+++ b/transacciones/views.py
@@ -603,7 +603,7 @@ def calcular_transaccion_completa(monto, moneda_origen, moneda_destino, cliente=
         
         # Obtener descuento del cliente
         descuento_pct = Decimal('0')
-        if cliente and cliente.tipo_cliente and cliente.tipo_cliente.descuento > 0:
+        if cliente and cliente.tipo_cliente and cliente.tipo_cliente.activo and cliente.tipo_cliente.descuento > 0:
             descuento_pct = Decimal(str(cliente.tipo_cliente.descuento))
         
         # LÓGICA :Cliente ingresa cuánto quiere PAGAR, sistema calcula cuánto RECIBE
@@ -791,7 +791,7 @@ def calcular_venta_completa(monto, moneda_origen, moneda_destino, cliente=None, 
         
         # Obtener descuento del cliente
         descuento_pct = Decimal('0')
-        if cliente and cliente.tipo_cliente and cliente.tipo_cliente.descuento > 0:
+        if cliente and cliente.tipo_cliente and cliente.tipo_cliente.activo and cliente.tipo_cliente.descuento > 0:
             descuento_pct = Decimal(str(cliente.tipo_cliente.descuento))
         
         # Obtener tasa de la divisa que va a vender


### PR DESCRIPTION
Al desactivar un Tipo Cliente todos los clientes de ese tipo pueden seguir operando pero sin el descuento que le corresponde a su tipo. 

Tambien se actualizó el formulario de creación y actualización de clientes para que se pueda crear un Cliente con un Tipo Cliente inactivo (Antes no se podia).

Y se actualizaron los tests.